### PR TITLE
Empty secrets file.

### DIFF
--- a/modules/spec/applications/default.nix
+++ b/modules/spec/applications/default.nix
@@ -117,14 +117,9 @@
       nushell
       fd
       vscode-extensions.vadimcn.vscode-lldb  # codelldb for VS Code
-
-      # TODO: Uncomment and configure ImageMagick
-      # imagemagick            # Image manipulation tool
-      # lua5_1                 # Lua 5.1 interpreter
-      # luarocks               # Lua package manager
-      # imagemagick-lua        # Lua bindings for ImageMagick
-      # lua51Packages.luarocks-nix
     ];
+
+    environment.shells = with pkgs; [ nushell ];
   };
 }
 

--- a/secrets/credentials.toml
+++ b/secrets/credentials.toml
@@ -1,0 +1,2 @@
+[users.jesse]
+hash = ""


### PR DESCRIPTION
Nix flakes error out when a file is called from the configuration, but is not committed. Staging an empty credentials file and ignoring future changes with `git update-index --assume-unchanged secrets/credentials.toml`. 